### PR TITLE
Individual AES keys per protocol in CryptoContextService

### DIFF
--- a/Server/Packets/ICryptoContextService.cs
+++ b/Server/Packets/ICryptoContextService.cs
@@ -6,11 +6,11 @@ using System.Threading.Tasks;
 
 namespace Moonlapse.Server.Packets {
     public interface ICryptoContextService {
-        void SetClientAESPrivateKey(byte[] key);
+        void SetClientAESPrivateKey(int protocolId, byte[] key);
         string GetServerRSAPublicKey();
-        byte[] AESEncrypt(byte[] plainText);
+        byte[] AESEncrypt(int protocolId, byte[] plainText);
         byte[] RSADecrypt(byte[] data);
-        byte[] AESDecrypt(byte[] data);
+        byte[] AESDecrypt(int protocolId, byte[] data);
         void GenerateRSAKeyPair();
     }
 }

--- a/Server/Packets/IPacketDeliveryService.cs
+++ b/Server/Packets/IPacketDeliveryService.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Moonlapse.Server.Packets {
     public interface IPacketDeliveryService {
-        public Task SendPacketAsync(Stream stream, Packet packet, PacketConfig? config = default);
-        public Task<Packet> ReceivePacketAsync(Stream stream);
+        public Task SendPacketAsync(int sendingProtocolId, Stream stream, Packet packet, PacketConfig? config = default);
+        public Task<Packet> ReceivePacketAsync(int receivingProtocolId, Stream stream);
     }
 }

--- a/Tests.Unit/Packets/TestPacketDeliveryService.cs
+++ b/Tests.Unit/Packets/TestPacketDeliveryService.cs
@@ -47,7 +47,7 @@ public class TestPacketDeliveryService {
         // Mock AES key packet
         var clientAes = Aes.Create();
         clientAESPrivateKey = clientAes.Key;
-        cryptoContextService.SetClientAESPrivateKey(clientAESPrivateKey);
+        cryptoContextService.SetClientAESPrivateKey(0, clientAESPrivateKey);
 
         mockAesKeyPacket = new() {
             AesKey = new() {
@@ -101,7 +101,7 @@ public class TestPacketDeliveryService {
         if (config.RSAEncrypted) {
             data = RsaEncrypt(data);
         } else if (config.AESEncrypted) {
-            data = cryptoContextService.AESEncrypt(data);
+            data = cryptoContextService.AESEncrypt(0, data);
         }
 
         stream.WriteByte(header);
@@ -116,7 +116,7 @@ public class TestPacketDeliveryService {
         WritePacketToStream(stream, mockAesKeyPacket);
 
         // read and reconstruct packet
-        var packet = await packetDeliveryService.ReceivePacketAsync(stream);
+        var packet = await packetDeliveryService.ReceivePacketAsync(0, stream);
 
         // tests
         Assert.Equal(mockAesKeyPacket, packet);
@@ -130,7 +130,7 @@ public class TestPacketDeliveryService {
         WritePacketToStream(stream, mockLoginPacket);
 
         // read and reconstruct packet
-        var packet = await packetDeliveryService.ReceivePacketAsync(stream);
+        var packet = await packetDeliveryService.ReceivePacketAsync(0, stream);
 
         // tests
         Assert.Equal(mockLoginPacket, packet);
@@ -148,11 +148,11 @@ public class TestPacketDeliveryService {
         stream.Position = 0;
 
         // read first packet
-        var packet = await packetDeliveryService.ReceivePacketAsync(stream);
+        var packet = await packetDeliveryService.ReceivePacketAsync(0, stream);
         Assert.Equal(mockChatPacket, packet);
 
         // read second packet
-        packet = await packetDeliveryService.ReceivePacketAsync(stream);
+        packet = await packetDeliveryService.ReceivePacketAsync(0, stream);
         Assert.Equal(mockChatPacket, packet);
     }
 
@@ -160,7 +160,7 @@ public class TestPacketDeliveryService {
     public void TestPacketSend() {
         // send the packet to mock stream
         var stream = new MemoryStream();
-        packetDeliveryService.SendPacketAsync(stream, mockChatPacket).Wait();
+        packetDeliveryService.SendPacketAsync(0, stream, mockChatPacket).Wait();
 
         // test bytes sent can be deserialized into original packet
         var data = stream.ToArray();
@@ -176,13 +176,13 @@ public class TestPacketDeliveryService {
     public void TestPacketLoop() {
         // send the packet to mock stream
         var stream = new MemoryStream();
-        packetDeliveryService.SendPacketAsync(stream, mockChatPacket).Wait();
+        packetDeliveryService.SendPacketAsync(0, stream, mockChatPacket).Wait();
 
         // resest stream position
         stream.Position = 0;
 
         // read stream
-        var packet = Task.Run(() => packetDeliveryService.ReceivePacketAsync(stream)).Result;
+        var packet = Task.Run(() => packetDeliveryService.ReceivePacketAsync(0, stream)).Result;
 
         // check equality
         Assert.Equal(mockChatPacket, packet);


### PR DESCRIPTION
When I made CryptoContext a shared service, I inadvertently made it so all protocols share the same CryptoContext, meaning they all have the same AES keys. We briefly realised this on Discord on Sunday but we both forgot about it before merging my PR.

I have made CryptoContextService hold a dictionary of protocols IDs to AES keys. This meant I had to update the PacketDeliveryService to use the protocolID for every send or receive. I think this is OK though, since we ideally don't use those methods directly, but thought I'd leave this PR for you to approve since I had to also change the IPacketDeliveryService interface and might have messed with your vision.